### PR TITLE
Removed option to change color based on party

### DIFF
--- a/views/partido.ejs
+++ b/views/partido.ejs
@@ -34,7 +34,8 @@
 
 
                 <!-- COLUMNA: Descripcion -->
-                <div class="col-lg-5 d-flex flex-column justify-content-start" style="background-color: <%- partido.color %> ;">
+                <!-- <div class="col-lg-5 d-flex flex-column justify-content-start" style="<%- //partido.color %>"> -->
+                <div class="col-lg-5 d-flex flex-column justify-content-start" style="background-color: #f7eee5;">
                     <div class="" style="width: 300px; margin: 0px auto; padding-top: 15px;">
                         <img src="<%- partido.logo %> " style="display: inline-block;" alt="..." width="286px">
                     </div>


### PR DESCRIPTION
Resulta que style="" lanza un error si dentro no posee un valor. 
Creo que un workaround sería almacenar la variable en el HTML, en un elemento con un id específico y luego llamar el texto de ese elemento desde un JS para actualizar el color.

Lo podemos ver después, pero de momento es bastante trabajo y el color que tenemos por defecto está bastante lindo.